### PR TITLE
Added depedency file generation/usage option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ TESTS_SRC ?=
 # lots of people use .cpp instead.
 CXX_EXT = cc
 
-# Use dependencies?
-USE_DEPS ?= y
-
 MKFILE_DIR ?= /home/peddie/programming/Makefile/
 
 include $(MKFILE_DIR)common_head.mk

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ TESTS_SRC ?=
 # lots of people use .cpp instead.
 CXX_EXT = cc
 
+# Use dependencies?
+USE_DEPS ?= y
+
 MKFILE_DIR ?= /home/peddie/programming/Makefile/
 
 include $(MKFILE_DIR)common_head.mk

--- a/build.mk
+++ b/build.mk
@@ -79,7 +79,7 @@ endif
 # worst of the non-portability.
 $(CUSTOM_C_OBJ) : %.$(OBJECT_FILE_SUFFIX) : %.c
 	@echo CC \(CUSTOM\) $(notdir $<)
-ifdef USE_DEPS
+ifndef NO_DEPS
 	$(Q)$(CC) -MM -MT $@ -MT $(basename $(basename $@)).d $(CUSTOM_CFLAGS) $< -MF $(basename $(basename $@)).d
 endif
 ifeq ("$(UNAME_OS)","Darwin")
@@ -90,7 +90,7 @@ endif
 
 $(filter-out $(CUSTOM_C_OBJ), $(C_OBJ)) : %.$(OBJECT_FILE_SUFFIX) : %.c # $(C_HDR)
 	@echo CC $(notdir $<)
-ifdef USE_DEPS
+ifndef NO_DEPS
 	$(Q)$(CC) -MM -MT $@ -MT $(basename $(basename $@)).d $(CFLAGS) $< -MF $(basename $(basename $@)).d
 endif
 ifeq ("$(UNAME_OS)","Darwin")
@@ -101,7 +101,7 @@ endif
 
 $(CUSTOM_CXX_OBJ) : %.$(OBJECT_FILE_SUFFIX) : %.$(CXX_EXT)
 	@echo CXX \(CUSTOM\) $(notdir $<)
-ifdef USE_DEPS
+ifndef NO_DEPS
 	$(Q)$(CXX) -MM -MT $@ -MT $(basename $(basename $@)).d $(CUSTOM_CXXFLAGS) $< -MF $(basename $(basename $@)).d
 endif
 ifeq ("$(UNAME_OS)","Darwin")
@@ -112,7 +112,7 @@ endif
 
 $(filter-out $(CUSTOM_CXX_OBJ), $(CXX_OBJ)) : %.$(OBJECT_FILE_SUFFIX) : %.$(CXX_EXT) # $(CXX_HDR)
 	@echo CXX $(notdir $<)
-ifdef USE_DEPS
+ifndef NO_DEPS
 	$(Q)$(CXX) -MM -MT $@ -MT $(basename $(basename $@)).d $(CXXFLAGS) $< -MF $(basename $(basename $@)).d
 endif
 ifeq ("$(UNAME_OS)","Darwin")
@@ -121,7 +121,7 @@ else
 	$(Q)$(CXX) $(CXXFLAGS) $(ASMFLAGS)$(@:%.$(OBJECT_FILE_SUFFIX)=%.$(ASMNAME)) -c $< -o $@
 endif
 
-ifdef USE_DEPS
+ifndef NO_DEPS
 -include $(DEPS)
 else
 $(OBJ) : $(HDR)

--- a/build.mk
+++ b/build.mk
@@ -79,6 +79,9 @@ endif
 # worst of the non-portability.
 $(CUSTOM_C_OBJ) : %.$(OBJECT_FILE_SUFFIX) : %.c
 	@echo CC \(CUSTOM\) $(notdir $<)
+ifdef USE_DEPS
+	$(Q)$(CC) -MM -MT $@ -MT $(basename $(basename $@)).d $(CUSTOM_CFLAGS) $< -MF $(basename $(basename $@)).d
+endif
 ifeq ("$(UNAME_OS)","Darwin")
 	$(Q)$(CC) $(CUSTOM_CFLAGS) -c $< -o $@
 else
@@ -87,6 +90,9 @@ endif
 
 $(filter-out $(CUSTOM_C_OBJ), $(C_OBJ)) : %.$(OBJECT_FILE_SUFFIX) : %.c # $(C_HDR)
 	@echo CC $(notdir $<)
+ifdef USE_DEPS
+	$(Q)$(CC) -MM -MT $@ -MT $(basename $(basename $@)).d $(CFLAGS) $< -MF $(basename $(basename $@)).d
+endif
 ifeq ("$(UNAME_OS)","Darwin")
 	$(Q)$(CC) $(CFLAGS) -c $< -o $@
 else
@@ -95,6 +101,9 @@ endif
 
 $(CUSTOM_CXX_OBJ) : %.$(OBJECT_FILE_SUFFIX) : %.$(CXX_EXT)
 	@echo CXX \(CUSTOM\) $(notdir $<)
+ifdef USE_DEPS
+	$(Q)$(CXX) -MM -MT $@ -MT $(basename $(basename $@)).d $(CUSTOM_CXXFLAGS) $< -MF $(basename $(basename $@)).d
+endif
 ifeq ("$(UNAME_OS)","Darwin")
 	$(Q)$(CXX) $(CUSTOM_CXXFLAGS) -c $< -o $@
 else
@@ -103,10 +112,17 @@ endif
 
 $(filter-out $(CUSTOM_CXX_OBJ), $(CXX_OBJ)) : %.$(OBJECT_FILE_SUFFIX) : %.$(CXX_EXT) # $(CXX_HDR)
 	@echo CXX $(notdir $<)
+ifdef USE_DEPS
+	$(Q)$(CXX) -MM -MT $@ -MT $(basename $(basename $@)).d $(CXXFLAGS) $< -MF $(basename $(basename $@)).d
+endif
 ifeq ("$(UNAME_OS)","Darwin")
 	$(Q)$(CXX) $(CXXFLAGS) -c $< -o $@
 else
 	$(Q)$(CXX) $(CXXFLAGS) $(ASMFLAGS)$(@:%.$(OBJECT_FILE_SUFFIX)=%.$(ASMNAME)) -c $< -o $@
 endif
 
+ifdef USE_DEPS
+-include $(DEPS)
+else
 $(OBJ) : $(HDR)
+endif

--- a/clean.mk
+++ b/clean.mk
@@ -9,6 +9,8 @@ clean:
 	$(Q)rm -f $(OBJ)
 # Clean up assembly listings
 	$(Q)rm -f $(ASM)
+# Clean up dependency files
+	$(Q)rm -f $(DEPS)
 ifdef LIBNAME
 # Clean up shared library
 	$(Q)rm -f $(LIBNAME).so

--- a/common_head.mk
+++ b/common_head.mk
@@ -54,6 +54,8 @@ SRC_SHORT = $(notdir $(SRC))
 ASM_SHORT = $(notdir $(ASM))
 OBJ_SHORT = $(notdir $(OBJ))
 
+# So make recognizes dependency files
+SUFFIXES += .d
 
 # Generate sweet mixed assembly/C listing files
 ASMFLAGS ?= -fverbose-asm -Wa,-L,-alchsdn=


### PR DESCRIPTION
If you define 'USE_DEPS' in your makefile, it should now create and use the .d dependencies, but if you don't define it, the makefile lib should work as before so that it's backward compatible.
